### PR TITLE
Change master to main

### DIFF
--- a/.github/workflows/hawkscan-local-bridge.yml
+++ b/.github/workflows/hawkscan-local-bridge.yml
@@ -4,11 +4,11 @@ name: HawkScan Local Bridge
 on:
   push:
     branches:
-      - master
+      - main
       - github/*
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   hawkscan:

--- a/.github/workflows/hawkscan-local-host.yml
+++ b/.github/workflows/hawkscan-local-host.yml
@@ -4,11 +4,11 @@ name: HawkScan Local Host
 on:
   push:
     branches:
-      - master
+      - main
       - github/*
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   hawkscan:

--- a/.github/workflows/hawkscan-remote.yml
+++ b/.github/workflows/hawkscan-remote.yml
@@ -3,11 +3,11 @@ name: HawkScan Remote
 on:
   push:
     branches:
-      - master
+      - main
       - github/*
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   hawkscan:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,13 @@
 branches:
   only:
-    - master
+    - main
     - /^travis.*$/
 
 language: generic
 
 env:
   global:
-    - APP_ENV='travis-ci'
+    - APP_ENV='Travis CI'
 
 services:
   - docker

--- a/README.md
+++ b/README.md
@@ -3,6 +3,22 @@
 Live integration tests for various CI/CD platforms.
 
 ## Branch Conventions
-Pushes and PRs to the `master` branch should kick off builds for every CI/CD integration defined in this repository. To reduce noise, we attempt to limit CI/CD triggers to master, and branches following a naming convention.
+Pushes and PRs to the `main` branch should kick off builds for every CI/CD integration defined in this repository. To reduce noise, we attempt to limit CI/CD triggers to main, and branches following a naming convention.
 
 For instance, branches that match the wildcard expression `github/*` should only trigger Github Actions builds. And branches named `concourse/*` should only trigger Concourse builds.
+
+## Active pipelines
+
+The following pipelines are defined:
+* GitHub Actions
+* Travis CI
+
+These are pending:
+* *Armory Spinnaker*
+* *AWS CodeBuild*
+* *Azure Pipeline*
+* *Circle CI*
+* *Concourse*
+* *GitLab*
+* *Google Cloud Build*
+* *Jenkins*


### PR DESCRIPTION
Update all docs and configs to refer to the new default `main` branch instead of `master`.